### PR TITLE
Use an options hash to pass tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Simple Ruby UDP client for the Plog Kafka forwarder.
 
 ### Build & run tests
 
-`gem build plog-ruby.gemspec`
-`rspec`
+```
+bundle install
+bundle exec rspec
+```
 
 ### Usage
 

--- a/lib/plog/client.rb
+++ b/lib/plog/client.rb
@@ -54,7 +54,7 @@ module Plog
       JSON.parse receive_packet_from_socket(timeout)
     end
 
-    def send(message, *tags)
+    def send(message, options = {})
       # Interpret the encoding of the string as binary so that chunking occurs
       # at the byte-level and not at the character-level.
       message = message.dup.force_encoding('BINARY')
@@ -76,7 +76,7 @@ module Plog
             chunks.count,
             index,
             data,
-            *tags
+            options
           ))
       end
 

--- a/lib/plog/packets/multipart_message.rb
+++ b/lib/plog/packets/multipart_message.rb
@@ -2,7 +2,7 @@ module Plog
   module Packets
 
     module MultipartMessage
-      def self.encode(message_id, length, checksum, chunk_size, count, index, payload, *tags)
+      def self.encode(message_id, length, checksum, chunk_size, count, index, payload, options = {})
         message = [
             PROTOCOL_VERSION,
             TYPE_MULTIPART_MESSAGE,
@@ -17,6 +17,7 @@ module Plog
         template = 'CCS>S>S>L>l>L>S>x2'
 
         # Generate pack template for tags
+        tags = options[:tags]
         if tags.nil? || tags.empty?
           message << 0
         else

--- a/lib/plog/version.rb
+++ b/lib/plog/version.rb
@@ -1,3 +1,3 @@
 module Plog
-  VERSION = '0.0.13'
+  VERSION = '0.0.14'
 end

--- a/spec/lib/plog/client_spec.rb
+++ b/spec/lib/plog/client_spec.rb
@@ -88,7 +88,8 @@ describe Plog::Client do
         chunk_size,
         anything(),
         anything(),
-        message
+        message,
+        {}
       ).and_call_original
       subject.send(message)
     end

--- a/spec/lib/plog/packets/multipart_message_spec.rb
+++ b/spec/lib/plog/packets/multipart_message_spec.rb
@@ -79,7 +79,7 @@ describe Plog::Packets::MultipartMessage do
         count,
         index,
         payload,
-        *tags
+        tags: tags
       )
     end
 


### PR DESCRIPTION
Splatted arguments are inefficient, not future proof.

@nelgau @jason-z-hang 
